### PR TITLE
actually use engineFromPath; invoke with the file path, not string

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var fs = require('fs')
 var RSVP = require('rsvp')
 var Filter = require('broccoli-filter')
 var cons = require('consolidate')
@@ -35,14 +36,15 @@ RenderTemplate.prototype.getDestFilePath = function(relativePath) {
   return null;
 }
 
-RenderTemplate.prototype.processString = function (string, relativePath) {
-  var options = this.options;
+RenderTemplate.prototype.processFile = function(srcDir, destDir, relativePath) {
+  var self = this;
   return new RSVP.Promise(function(resolve, reject){
-    cons.handlebars.render(string, options, function(e, html){
+    self.engineFromPath(relativePath)(srcDir + '/' + relativePath, self.options, function(e, html){
       if (e) {
         reject(e)
       } else {
-        resolve(html)
+        var outputPath = self.getDestFilePath(relativePath)
+        resolve(fs.writeFileSync(destDir + '/' + outputPath, html, { encoding: 'utf8' }))
       }
     })
   })


### PR DESCRIPTION
First of all, you left the "handlebars" constant there ;-)
Secondly, we should pass the file path, not the string. Otherwise, we break eg. `extends` in swig.
